### PR TITLE
Fix for FNF chords showing as split notes in the path notation.

### DIFF
--- a/src/points.cpp
+++ b/src/points.cpp
@@ -301,7 +301,6 @@ void apply_multiplier(std::vector<Point>& points, const Engine& engine)
 bool has_split_notes(SightRead::TrackType track_type)
 {
     return track_type == SightRead::TrackType::Drums
-        || track_type == SightRead::TrackType::FortniteFestival;
 }
 
 bool is_note_skippable(const SightRead::Note& starting_note,
@@ -311,9 +310,6 @@ bool is_note_skippable(const SightRead::Note& starting_note,
 {
     if (track_type == SightRead::TrackType::Drums) {
         return note_to_test.is_skipped_kick(drum_settings);
-    }
-    if (track_type == SightRead::TrackType::FortniteFestival) {
-        return false;
     }
     return starting_note.position == note_to_test.position;
 }


### PR DESCRIPTION
Currently CHOpt has FNF notes not counting chords properly, this is because it considers chords split notes since the actual game allows you to hit the individual notes in chords separately on non-pro instruments.

This leads to the path notation to be really hard to follow across all instruments. Removing the split note check for Festival fixes this issue.